### PR TITLE
Cleanup and activate pylint in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ install:
 # command to run tests, e.g. python setup.py test
 script:
   - tox -e $(echo py$TRAVIS_PYTHON_VERSION | tr -d .)
-  - pylint neo_batterylevelshutdown
+  - pylint --extension-pkg-whitelist=RPi.GPIO neo_batterylevelshutdown

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ install:
 
 # command to run tests, e.g. python setup.py test
 script:
-  - python -c "import distutils; print(distutils.__version__)"
+  - python -c "import distutils; print(distutils.dir_util)"
   - tox -e $(echo py$TRAVIS_PYTHON_VERSION | tr -d .)
   - pylint neo_batterylevelshutdown

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,11 @@
 
 language: python
 python:
-  - "3.4"
   - "3.5"
-  - "3.6"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
+  - pip install .
   - pip install tox pylint
 
 # command to run tests, e.g. python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,9 @@ python:
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
-  - pip install tox
+  - pip install tox pylint
 
 # command to run tests, e.g. python setup.py test
 script:
   - tox -e $(echo py$TRAVIS_PYTHON_VERSION | tr -d .)
-
-
+  - pylint neo_batterylevelshutdown

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
 
 # command to run tests, e.g. python setup.py test
 script:
-  - python -c "import distutils; print(distutils.dir_util)"
+  - python35 -c "import distutils; print(distutils.dir_util)"
+  - python --version
   - tox -e $(echo py$TRAVIS_PYTHON_VERSION | tr -d .)
   - pylint neo_batterylevelshutdown

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ language: python
 python:
   - "3.5"
 
-# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
+# We need to bump pip because the travis default version doesn't allow
+#  dependency install via URL
 install:
   - pip install --upgrade pip
   - pip install -e .
@@ -14,4 +15,4 @@ install:
 # command to run tests, e.g. python setup.py test
 script:
   - tox -e $(echo py$TRAVIS_PYTHON_VERSION | tr -d .)
-  - pylint --extension-pkg-whitelist=RPi.GPIO neo_batterylevelshutdown
+  - pylint neo_batterylevelshutdown

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
-  - pip install .
+  - pip install -e .
   - pip install tox pylint
 
 # command to run tests, e.g. python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,5 @@ install:
 
 # command to run tests, e.g. python setup.py test
 script:
-  - python35 -c "import distutils; print(distutils.dir_util)"
-  - python --version
   - tox -e $(echo py$TRAVIS_PYTHON_VERSION | tr -d .)
   - pylint neo_batterylevelshutdown

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,6 @@ install:
 
 # command to run tests, e.g. python setup.py test
 script:
+  - python -c "import distutils; print(distutils.__version__)"
   - tox -e $(echo py$TRAVIS_PYTHON_VERSION | tr -d .)
   - pylint neo_batterylevelshutdown

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
+  - pip install --upgrade pip
   - pip install -e .
   - pip install tox pylint
 

--- a/pylintrc
+++ b/pylintrc
@@ -163,7 +163,7 @@ ignored-classes=optparse.Values,thread._local,_thread._local
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
+ignored-modules=RPi.GPIO
 
 # Show a hint with possible names when a member name was not found. The aspect
 # of finding the hint is based on edit distance.

--- a/pylintrc
+++ b/pylintrc
@@ -163,7 +163,7 @@ ignored-classes=optparse.Values,thread._local,_thread._local
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=RPi.GPIO
+ignored-modules=RPi.GPIO,distutils
 
 # Show a hint with possible names when a member name was not found. The aspect
 # of finding the hint is based on edit distance.


### PR DESCRIPTION
Includes removing CI runs for py34 and py36 given debian9 ships with py35 and that's what we use.